### PR TITLE
Tolerate lack of sRGB extension.

### DIFF
--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ function loadCubeMap(gl, envMap, type, state) {
                     gl.bindTexture(gl.TEXTURE_CUBE_MAP, texture);
                     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
                     // todo:  should this be srgb?  or rgba?  what's the HDR scale on this?
-                    gl.texImage2D(face, j, gl.hasSRGBExt.SRGB_EXT, gl.hasSRGBExt.SRGB_EXT, gl.UNSIGNED_BYTE, image);
+                    gl.texImage2D(face, j, state.sRGBifAvailable, state.sRGBifAvailable, gl.UNSIGNED_BYTE, image);
                 }
             }(texture, face, image, j);
             image.src = faces[i][0];
@@ -139,14 +139,15 @@ function init(vertSource, fragSource) {
     // Load extensions
     gl.hasLodExt = gl.getExtension('EXT_shader_texture_lod');
     gl.hasDerivativesExt = gl.getExtension('OES_standard_derivatives');
-    gl.hasSRGBExt = gl.getExtension('EXT_SRGB');
+    var hasSRGBExt = gl.getExtension('EXT_SRGB');
 
     glState = {
         uniforms: {},
         attributes: {},
         vertSource: vertSource,
         fragSource: fragSource,
-        scene: null
+        scene: null,
+        sRGBifAvailable: (hasSRGBExt ? hasSRGBExt.SRGB_EXT : gl.RGBA)
     };
 
     var projectionMatrix = mat4.create();
@@ -438,7 +439,7 @@ function handleMouseMove(ev, redraw) {
 var wheelSpeed = 1.04;
 function handleWheel(ev, redraw) {
     ev.preventDefault();
-    if (ev.wheelDelta > 0) {
+    if (ev.deltaY > 0) {
         translate *= wheelSpeed;
     }
     else {

--- a/scene.js
+++ b/scene.js
@@ -19,7 +19,8 @@ class Mesh {
             uniformLocations: {},
             attributes: {},
             vertSource: globalState.vertSource,
-            fragSource: globalState.fragSource
+            fragSource: globalState.fragSource,
+            sRGBifAvailable : globalState.sRGBifAvailable
         };
 
         var primitives = gltf.meshes[meshIdx].primitives;
@@ -227,7 +228,7 @@ class Mesh {
         if (pbrMat && pbrMat.baseColorTexture && gltf.textures.length > pbrMat.baseColorTexture.index) {
             var baseColorTexInfo = gltf.textures[pbrMat.baseColorTexture.index];
             var baseColorSrc = this.modelPath + gltf.images[baseColorTexInfo.source].uri;
-            imageInfos['baseColor'] = { 'uri': baseColorSrc, 'samplerIndex': samplerIndex, 'colorSpace': gl.hasSRGBExt.SRGB_EXT }; // colorSpace, samplerindex, uri
+            imageInfos['baseColor'] = { 'uri': baseColorSrc, 'samplerIndex': samplerIndex, 'colorSpace': this.glState.sRGBifAvailable }; // colorSpace, samplerindex, uri
             this.glState.uniforms['u_BaseColorSampler'] = { 'funcName': 'uniform1i', 'vals': [samplerIndex] };
             samplerIndex++;
             this.defines.HAS_BASECOLORMAP = 1;
@@ -287,7 +288,7 @@ class Mesh {
         if (this.material && this.material.emissiveTexture) {
             var emissiveTexInfo = gltf.textures[this.material.emissiveTexture.index];
             var emissiveSrc = this.modelPath + gltf.images[emissiveTexInfo.source].uri;
-            imageInfos['emissive'] = { 'uri': emissiveSrc, 'samplerIndex': samplerIndex, 'colorSpace': gl.hasSRGBExt.SRGB_EXT }; // colorSpace, samplerindex, uri
+            imageInfos['emissive'] = { 'uri': emissiveSrc, 'samplerIndex': samplerIndex, 'colorSpace': this.glState.sRGBifAvailable }; // colorSpace, samplerindex, uri
             this.glState.uniforms['u_EmissiveSampler'] = { 'funcName': 'uniform1i', 'vals': [samplerIndex] };
             samplerIndex++;
             this.defines.HAS_EMISSIVEMAP = 1;


### PR DESCRIPTION
This makes the sRGB extension optional, and adds a fallback to RGBA.

Also it tweaks the mouse-wheel code to be more cross-browser compatible.

Together, these changes should allow this app to run correctly in the Firefox and Edge browsers.

Affects #1 and #3.