### PR TITLE
Minor fix to adhere to spec for roughness and metallic factors.

### DIFF
--- a/scene.js
+++ b/scene.js
@@ -238,6 +238,12 @@ class Mesh {
         }
 
         // Metallic-Roughness
+        var metallic = (pbrMat && defined(pbrMat.metallicFactor)) ? pbrMat.metallicFactor : 1.0;
+        var roughness = (pbrMat && defined(pbrMat.roughnessFactor)) ? pbrMat.roughnessFactor : 1.0;
+        this.glState.uniforms['u_MetallicRoughnessValues'] = {
+            funcName: 'uniform2f',
+            vals: [metallic, roughness]
+        };
         if (pbrMat && pbrMat.metallicRoughnessTexture && gltf.textures.length > pbrMat.metallicRoughnessTexture.index) {
             var mrTexInfo = gltf.textures[pbrMat.metallicRoughnessTexture.index];
             var mrSrc = this.modelPath + gltf.images[mrTexInfo.source].uri;
@@ -254,12 +260,6 @@ class Mesh {
             if (this.glState.uniforms['u_MetallicRoughnessSampler']) {
                 delete this.glState.uniforms['u_MetallicRoughnessSampler'];
             }
-            var metallic = (pbrMat && defined(pbrMat.metallicFactor)) ? pbrMat.metallicFactor : 1.0;
-            var roughness = (pbrMat && defined(pbrMat.roughnessFactor)) ? pbrMat.roughnessFactor : 1.0;
-            this.glState.uniforms['u_MetallicRoughnessValues'] = {
-                funcName: 'uniform2f',
-                vals: [metallic, roughness]
-            };
         }
 
         // Normals

--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -23,9 +23,8 @@ uniform sampler2D u_EmissiveSampler;
 #endif
 #ifdef HAS_METALROUGHNESSMAP
 uniform sampler2D u_MetallicRoughnessSampler;
-#else
-uniform vec2 u_MetallicRoughnessValues;
 #endif
+uniform vec2 u_MetallicRoughnessValues;
 #ifdef HAS_OCCLUSIONMAP
 uniform sampler2D u_OcclusionSampler;
 #endif
@@ -178,13 +177,12 @@ void main() {
   float LdotH = clamp(dot(l,h), 0.0, 1.0);
   float VdotH = clamp(dot(v,h), 0.0, 1.0);
 
-  #ifdef HAS_METALROUGHNESSMAP
-  vec4 mrSample = texture2D(u_MetallicRoughnessSampler, v_UV);
-  float roughness = clamp(mrSample.g, 0.04, 1.0);
-  float metallic = clamp(mrSample.b, 0.0, 1.0);
-  #else
   float roughness = clamp(u_MetallicRoughnessValues.y, 0.04, 1.0);
   float metallic = u_MetallicRoughnessValues.x;
+  #ifdef HAS_METALROUGHNESSMAP
+  vec4 mrSample = texture2D(u_MetallicRoughnessSampler, v_UV);
+  roughness = clamp(mrSample.g * roughness, 0.04, 1.0);
+  metallic = clamp(mrSample.b * metallic, 0.0, 1.0);
   #endif
 
   #ifdef HAS_BASECOLORMAP


### PR DESCRIPTION
I happened to notice this today when reviewing this amazing repository with @emackey.  Roughness and metallic factor uniforms should always be defined in the pbr fragment shaders.  From the spec:
"If both factors and textures are present the factor value acts as a linear multiplier for the corresponding texture values."