### PR TITLE
Fix to denominator of Cook-Torrance brdf

### DIFF
--- a/scene.js
+++ b/scene.js
@@ -252,9 +252,6 @@ class Mesh {
             this.glState.uniforms['u_MetallicRoughnessSampler'] = { 'funcName': 'uniform1i', 'vals': [samplerIndex] };
             samplerIndex++;
             this.defines.HAS_METALROUGHNESSMAP = 1;
-            if (this.glState.uniforms['u_MetallicRoughnessValues']) {
-                delete this.glState.uniforms['u_MetallicRoughnessValues'];
-            }
         }
         else {
             if (this.glState.uniforms['u_MetallicRoughnessSampler']) {

--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -171,8 +171,8 @@ void main() {
   vec3 h = normalize(l+v);
   vec3 reflection = -normalize(reflect(v, n));
 
-  float NdotL = clamp(dot(n,l), 0.0001, 1.0);
-  float NdotV = clamp(dot(n,v), 0.0001, 1.0);
+  float NdotL = clamp(dot(n,l), 0.001, 1.0);
+  float NdotV = abs(dot(n,v)) + 0.001;
   float NdotH = clamp(dot(n,h), 0.0, 1.0);
   float LdotH = clamp(dot(l,h), 0.0, 1.0);
   float VdotH = clamp(dot(v,h), 0.0, 1.0);
@@ -200,14 +200,14 @@ void main() {
 
   #ifdef USE_MATHS
 
-  	// Compute reflectance.
-	float reflectance = max(max(specularColor.r, specularColor.g), specularColor.b);
+  // Compute reflectance.
+  float reflectance = max(max(specularColor.r, specularColor.g), specularColor.b);
 
-	// For typical incident reflectance range (between 4% to 100%) set the grazing reflectance to 100% for typical fresnel effect.
+  // For typical incident reflectance range (between 4% to 100%) set the grazing reflectance to 100% for typical fresnel effect.
   // For very low reflectance range on highly diffuse objects (below 4%), incrementally reduce grazing reflecance to 0%.
   float reflectance90 = clamp(reflectance * 25.0, 0.0, 1.0);
-	vec3 specularEnvironmentR0 = specularColor.rgb;
-	vec3 specularEnvironmentR90 = vec3(1.0, 1.0, 1.0) * reflectance90;
+  vec3 specularEnvironmentR0 = specularColor.rgb;
+  vec3 specularEnvironmentR90 = vec3(1.0, 1.0, 1.0) * reflectance90;
 
   PBRInfo pbrInputs = PBRInfo(
     NdotL,
@@ -230,12 +230,12 @@ void main() {
   float G = SmithVisibilityGGX(pbrInputs);
   float D = GGX(pbrInputs);
 
-  vec3 diffuseContrib = (1.0 - F) * lambertianDiffuse(pbrInputs) * NdotL * u_LightColor;
-  //vec3 diffuseContrib = (1.0 - F) * disneyDiffuse(pbrInputs) * NdotL * u_LightColor;
+  vec3 diffuseContrib = (1.0 - F) * lambertianDiffuse(pbrInputs);
+  //vec3 diffuseContrib = (1.0 - F) * disneyDiffuse(pbrInputs);
 
-  vec3 specContrib = M_PI * u_LightColor * F * G * D / (4.0 * NdotL * NdotV);
+  vec3 specContrib = F * G * D / (4.0 * NdotL * NdotV);
 
-  vec3 color = (diffuseContrib + specContrib);
+  vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
   #endif
 
   #ifdef USE_IBL

--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -171,8 +171,8 @@ void main() {
   vec3 h = normalize(l+v);
   vec3 reflection = -normalize(reflect(v, n));
 
-  float NdotL = clamp(dot(n,l), 0.0, 1.0);
-  float NdotV = clamp(dot(n,v), 0.0, 1.0);
+  float NdotL = clamp(dot(n,l), 0.0001, 1.0);
+  float NdotV = clamp(dot(n,v), 0.0001, 1.0);
   float NdotH = clamp(dot(n,h), 0.0, 1.0);
   float LdotH = clamp(dot(l,h), 0.0, 1.0);
   float VdotH = clamp(dot(v,h), 0.0, 1.0);
@@ -233,7 +233,7 @@ void main() {
   vec3 diffuseContrib = (1.0 - F) * lambertianDiffuse(pbrInputs) * NdotL * u_LightColor;
   //vec3 diffuseContrib = (1.0 - F) * disneyDiffuse(pbrInputs) * NdotL * u_LightColor;
 
-  vec3 specContrib = M_PI * u_LightColor * F * G * D / 4.0*NdotL*NdotV;
+  vec3 specContrib = M_PI * u_LightColor * F * G * D / (4.0 * NdotL * NdotV);
 
   vec3 color = (diffuseContrib + specContrib);
   #endif


### PR DESCRIPTION
I believe that there are parentheses missing in the denominator for the Cook-Torrance BRDF.  This would add a possible divide-by-zero error, so I padded the dot products a little. Does this seem correct to you?