### PR TITLE
Add attribution for the shader equations, also some misc cleanup

### DIFF
--- a/main.js
+++ b/main.js
@@ -136,9 +136,6 @@ function init(vertSource, fragSource) {
 
     var ctx2d = canvas2d.getContext("2d");
 
-    // Load extensions
-    gl.hasLodExt = gl.getExtension('EXT_shader_texture_lod');
-    gl.hasDerivativesExt = gl.getExtension('OES_standard_derivatives');
     var hasSRGBExt = gl.getExtension('EXT_SRGB');
 
     glState = {
@@ -147,6 +144,8 @@ function init(vertSource, fragSource) {
         vertSource: vertSource,
         fragSource: fragSource,
         scene: null,
+        hasLODExtension:gl.getExtension('EXT_shader_texture_lod'),
+        hasDerivativesExtension:gl.getExtension('OES_standard_derivatives'),
         sRGBifAvailable: (hasSRGBExt ? hasSRGBExt.SRGB_EXT : gl.RGBA)
     };
 
@@ -170,7 +169,7 @@ function init(vertSource, fragSource) {
     // Get location of mvp matrix uniform
     glState.uniforms['u_mvpMatrix'] = { 'funcName': 'uniformMatrix4fv' };
     // Get location of normal matrix uniform
-    glState.uniforms['u_NormalMatrix'] = { 'funcName': 'uniformMatrix4fv' };
+    glState.uniforms['u_modelMatrix'] = { 'funcName': 'uniformMatrix4fv' };
 
     // Light
     glState.uniforms['u_LightDirection'] = { 'funcName': 'uniform3f', 'vals': [0.0, 0.5, 0.5] };

--- a/shaders/pbr-vert.glsl
+++ b/shaders/pbr-vert.glsl
@@ -10,7 +10,7 @@ attribute vec2 a_UV;
 #endif
 
 uniform mat4 u_mvpMatrix;
-uniform mat4 u_NormalMatrix;
+uniform mat4 u_modelMatrix;
 
 varying vec3 v_Position;
 varying vec2 v_UV;
@@ -19,24 +19,24 @@ varying vec2 v_UV;
 #ifdef HAS_TANGENTS
 varying mat3 v_TBN;
 #else
-varying vec3 v_Normal; 
+varying vec3 v_Normal;
 #endif
 #endif
 
 
 void main(){
-  vec4 pos = u_NormalMatrix * a_Position;
+  vec4 pos = u_modelMatrix * a_Position;
   v_Position = vec3(pos.xyz) / pos.w;
 
 
   #ifdef HAS_NORMALS
   #ifdef HAS_TANGENTS
-  vec3 normalW = normalize(vec3(u_NormalMatrix * vec4(a_Normal.xyz, 0.0)));
-	vec3 tangentW = normalize(vec3(u_NormalMatrix * vec4(a_Tangent.xyz, 0.0)));
+  vec3 normalW = normalize(vec3(u_modelMatrix * vec4(a_Normal.xyz, 0.0)));
+	vec3 tangentW = normalize(vec3(u_modelMatrix * vec4(a_Tangent.xyz, 0.0)));
 	vec3 bitangentW = cross(normalW, tangentW) * a_Tangent.w;
 	v_TBN = mat3(tangentW, bitangentW, normalW);
   #else // HAS_TANGENTS != 1
-  v_Normal = normalize(vec3(u_NormalMatrix * a_Normal));
+  v_Normal = normalize(vec3(u_modelMatrix * a_Normal));
   #endif
   #endif
 


### PR DESCRIPTION
Rename the "normal matrix" to better reflect its usage as a transform from model -> world
Don't modify the gl context, instead store information about extensions in the state
move the camera/view calculations outside of the per-mesh loop
Add information about which papers the different lighting information came from to the shader.