### PR TITLE
Added missing pbr factors.

### DIFF
--- a/scene.js
+++ b/scene.js
@@ -209,6 +209,11 @@ class Mesh {
         var samplerIndex = 3; // skip the first three because of the cubemaps
 
         // Base Color
+        var baseColorFactor = pbrMat && defined(pbrMat.baseColorFactor) ? pbrMat.baseColorFactor : [1.0, 1.0, 1.0, 1.0];
+        this.glState.uniforms['u_BaseColorFactor'] = {
+            funcName: 'uniform4f',
+            vals: baseColorFactor
+        };
         if (pbrMat && pbrMat.baseColorTexture && gltf.textures.length > pbrMat.baseColorTexture.index) {
             var baseColorTexInfo = gltf.textures[pbrMat.baseColorTexture.index];
             var baseColorSrc = this.modelPath + gltf.images[baseColorTexInfo.source].uri;
@@ -245,6 +250,7 @@ class Mesh {
 
         // Normals
         if (this.material && this.material.normalTexture && gltf.textures.length > this.material.normalTexture.index) {
+            var normalScale = defined(this.material.normalTexture.scale) ? this.material.normalTexture.scale : 1.0;
             var normalsTexInfo = gltf.textures[this.material.normalTexture.index];
             var normalsSrc = this.modelPath + gltf.images[normalsTexInfo.source].uri;
             imageInfos['normal'] = { 'uri': normalsSrc, 'samplerIndex': samplerIndex, 'colorSpace': gl.RGBA };
@@ -252,6 +258,7 @@ class Mesh {
                 funcName: 'uniform1i',
                 vals: [samplerIndex]
             };
+            this.glState.uniforms['u_NormalScale'] = { 'funcName': 'uniform1f', 'vals': [normalScale] };
             samplerIndex++;
             this.defines.HAS_NORMALMAP = 1;
         }
@@ -273,6 +280,11 @@ class Mesh {
             this.glState.uniforms['u_EmissiveSampler'] = { 'funcName': 'uniform1i', 'vals': [samplerIndex] };
             samplerIndex++;
             this.defines.HAS_EMISSIVEMAP = 1;
+            var emissiveFactor = defined(this.material.emissiveFactor) ? this.material.emissiveFactor : [0.0, 0.0, 0.0];
+            this.glState.uniforms['u_EmissiveFactor'] = {
+                funcName: 'uniform3f',
+                vals: emissiveFactor
+            };
         }
         else if (this.glState.uniforms['u_EmissiveSampler']) {
             delete this.glState.uniforms['u_EmissiveSampler'];
@@ -280,10 +292,12 @@ class Mesh {
 
         // AO
         if (this.material && this.material.occlusionTexture) {
+            var occlusionStrength = defined(this.material.occlusionTexture.strength) ? this.material.occlusionTexture.strength : 1.0;
             var occlusionTexInfo = gltf.textures[this.material.occlusionTexture.index];
             var occlusionSrc = this.modelPath + gltf.images[occlusionTexInfo.source].uri;
             imageInfos['occlusion'] = { 'uri': occlusionSrc, 'samplerIndex': samplerIndex, 'colorSpace': gl.RGBA };
             this.glState.uniforms['u_OcclusionSampler'] = { 'funcName': 'uniform1i', 'vals': [samplerIndex] };
+            this.glState.uniforms['u_OcclusionStrength'] = { 'funcName': 'uniform1f', 'vals': [occlusionStrength] };
             samplerIndex++;
             this.defines.HAS_OCCLUSIONMAP = 1;
         }

--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -66,6 +66,7 @@ struct PBRInfo
 };
 
 const float M_PI = 3.141592653589793;
+const float c_MinRoughness = 0.04;
 
 // The following equations model the diffuse term of the lighting equation
 // Implementation of diffuse from "Physically-Based Shading at Disney" by Brent Burley
@@ -190,13 +191,16 @@ void main() {
   float LdotH = clamp(dot(l,h), 0.0, 1.0);
   float VdotH = clamp(dot(v,h), 0.0, 1.0);
 
-  float roughness = clamp(u_MetallicRoughnessValues.y, 0.04, 1.0);
+  float roughness = u_MetallicRoughnessValues.y;
   float metallic = u_MetallicRoughnessValues.x;
   #ifdef HAS_METALROUGHNESSMAP
   vec4 mrSample = texture2D(u_MetallicRoughnessSampler, v_UV);
-  roughness = clamp(mrSample.g * roughness, 0.04, 1.0);
-  metallic = clamp(mrSample.b * metallic, 0.0, 1.0);
+  roughness = mrSample.g * roughness;
+  metallic = mrSample.b * metallic;
   #endif
+
+  roughness = clamp(roughness, c_MinRoughness, 1.0);
+  metallic = clamp(metallic, 0.0, 1.0);
 
   #ifdef HAS_BASECOLORMAP
   vec4 baseColor = texture2D(u_BaseColorSampler, v_UV) * u_BaseColorFactor;


### PR DESCRIPTION
This PR wires up the uniforms for controlling occlusionStrength, normalScale, emissiveFactor, and baseColorFactor.  This fixes #13.

The shader implementation and defaults should match the recommendations in the spec.  I also found this glTF issue for additional background and guidance:
@KhronosGroup/glTF#885

CC @emackey @javagl 