### PR TITLE
Make sure material exists before checking doubleSided flag.

### DIFF
--- a/scene.js
+++ b/scene.js
@@ -111,7 +111,7 @@ class Mesh {
         var modelMatrix = mat4.create();
         mat4.multiply(modelMatrix, modelMatrix, transform);
 
-        if (this.material.doubleSided) {
+        if (this.material && this.material.doubleSided) {
             gl.disable(gl.CULL_FACE);
         } else {
             gl.enable(gl.CULL_FACE);


### PR DESCRIPTION
Fixes #27.

The "Triangle" model should be working again after this fix.