### PR TITLE
PBR Fragment Shader Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,49 +106,50 @@ Appendix
 ------------
 
 In this section, you'll find alternative implementations for the various terms found in the lighting equation.
+These functions may be swapped into pbr-frag.glsl to tune your desired rendering performance and presentation.
 
 ### Surface Reflection Ratio (F)
 
 **Frensel Schlick**
-Simplified implementation of fresnel from "An Inexpensive BRDF Model for Physically based Rendering" by Christophe Schlick.
+Simplified implementation of fresnel from [An Inexpensive BRDF Model for Physically based Rendering](https://www.cs.virginia.edu/~jdl/bib/appearance/analytic%20models/schlick94b.pdf) by Christophe Schlick.
 
 ```
 vec3 specularReflection(PBRInfo pbrInputs)
 {
-  return pbrInputs.metalness + (vec3(1.0) - pbrInputs.metalness) * pow(1.0 - pbrInputs.VdotH, 5.0);
+    return pbrInputs.metalness + (vec3(1.0) - pbrInputs.metalness) * pow(1.0 - pbrInputs.VdotH, 5.0);
 }
 ```
 
 ### Geometric Occlusion (G)
 
 **Cook Torrance**
-The following equations model the geometric occlusion term of the spec equation  (aka G()). Implementation from "A Reflectance Model for Computer Graphics" by Robert Cook and Kenneth Torrance,
+Implementation from [A Reflectance Model for Computer Graphics](http://graphics.pixar.com/library/ReflectanceModel/) by Robert Cook and Kenneth Torrance,
 
 ```
 float geometricOcclusion(PBRInfo pbrInputs)
 {
-  return min(min(2.0 * pbrInputs.NdotV * pbrInputs.NdotH / pbrInputs.VdotH, 2.0 * pbrInputs.NdotL * pbrInputs.NdotH / pbrInputs.VdotH), 1.0);
+    return min(min(2.0 * pbrInputs.NdotV * pbrInputs.NdotH / pbrInputs.VdotH, 2.0 * pbrInputs.NdotL * pbrInputs.NdotH / pbrInputs.VdotH), 1.0);
 }
 ```
 
 **Schlick**
-Implementation of microfacet occlusion from "An Inexpensive BRDF Model for Physically based Rendering" by Christophe Schlick
+Implementation of microfacet occlusion from [An Inexpensive BRDF Model for Physically based Rendering](https://www.cs.virginia.edu/~jdl/bib/appearance/analytic%20models/schlick94b.pdf) by Christophe Schlick.
 
 ```
 float geometricOcclusion(PBRInfo pbrInputs)
 {
-  float k = pbrInputs.perceptualRoughness * 0.79788; // 0.79788 = sqrt(2.0/3.1415); perceptualRoughness = sqrt(alphaRoughness);
-  // alternately, k can be defined with
-  // float k = (pbrInputs.perceptualRoughness + 1) * (pbrInputs.perceptualRoughness + 1) / 8;
+    float k = pbrInputs.perceptualRoughness * 0.79788; // 0.79788 = sqrt(2.0/3.1415); perceptualRoughness = sqrt(alphaRoughness);
+    // alternately, k can be defined with
+    // float k = (pbrInputs.perceptualRoughness + 1) * (pbrInputs.perceptualRoughness + 1) / 8;
 
-  float l = pbrInputs.LdotH / (pbrInputs.LdotH * (1.0 - k) + k);
-  float n = pbrInputs.NdotH / (pbrInputs.NdotH * (1.0 - k) + k);
-  return l * n;
+    float l = pbrInputs.LdotH / (pbrInputs.LdotH * (1.0 - k) + k);
+    float n = pbrInputs.NdotH / (pbrInputs.NdotH * (1.0 - k) + k);
+    return l * n;
 }
 ```
 
 **Smith**
-The following Smith implementations are from “Geometrical Shadowing of a Random Rough Surface” by Bruce G. Smith
+The following implementation is from "Geometrical Shadowing of a Random Rough Surface" by Bruce G. Smith
 
 ```
 float geometricOcclusion(PBRInfo pbrInputs)
@@ -165,13 +166,13 @@ float geometricOcclusion(PBRInfo pbrInputs)
 The following equations model the diffuse term of the lighting equation.
 
 ***Disney***
-Implementation of diffuse from "Physically-Based Shading at Disney" by Brent Burley
+Implementation of diffuse from [Physically-Based Shading at Disney](http://blog.selfshadow.com/publications/s2012-shading-course/burley/s2012_pbs_disney_brdf_notes_v3.pdf) by Brent Burley.  See Section 5.3.
 
 ```
 vec3 diffuse(PBRInfo pbrInputs)
 {
-  float f90 = 2.0 * pbrInputs.LdotH * pbrInputs.LdotH * pbrInputs.alphaRoughness - 0.5;
+    float f90 = 2.0 * pbrInputs.LdotH * pbrInputs.LdotH * pbrInputs.alphaRoughness - 0.5;
 
-  return (pbrInputs.baseColor / M_PI) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotL), 5.0)) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotV), 5.0));
+    return (pbrInputs.baseColor / M_PI) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotL), 5.0)) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotV), 5.0));
 }
 ```

--- a/README.md
+++ b/README.md
@@ -173,6 +173,6 @@ vec3 diffuse(PBRInfo pbrInputs)
 {
     float f90 = 2.0 * pbrInputs.LdotH * pbrInputs.LdotH * pbrInputs.alphaRoughness - 0.5;
 
-    return (pbrInputs.baseColor / M_PI) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotL), 5.0)) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotV), 5.0));
+    return (pbrInputs.diffuseColor / M_PI) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotL), 5.0)) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotV), 5.0));
 }
 ```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ It is first important to choose a microfacet model to describe how light interac
 
 ### Environment Maps
 
-This is where environment maps come in! Environement maps can be thought of as a light source that surrounds the entire scene (usually as an encompassing cube or sphere) and contributes to the lighting based on the color and brightness across the entire image. As you might guess, it is extremely inefficient to assess the light contribution to a single point on a surface from every visible point on the environment map. In offline applications, we would typically resort to using importance sampling within the render and just choose a predefined number of samples. However, as described in [Unreal Engine's course notes on real-time PBR](http://blog.selfshadow.com/publications/s2013-shading-course/karis/s2013_pbs_epic_notes_v2.pdf), we can reduce this to a single texture lookup by baking the diffuse and specular irradiance contributions of the environment map into textures. You could do this youself as described in the course notes, but there is also a resource called [IBL Baker](http://www.derkreature.com/iblbaker/) that will create these textures for you. The diffuse irradiance can be stored in a cube map, however, we expect the sharpness of specular reflection to diminish as the roughness of the object increases. Because of this, the different amounts of specular irradiance can be stored in the mip levels of the specular cube map and accessed in the fragment shader based on roughness.
+This is where environment maps come in! Environment maps can be thought of as a light source that surrounds the entire scene (usually as an encompassing cube or sphere) and contributes to the lighting based on the color and brightness across the entire image. As you might guess, it is extremely inefficient to assess the light contribution to a single point on a surface from every visible point on the environment map. In offline applications, we would typically resort to using importance sampling within the render and just choose a predefined number of samples. However, as described in [Unreal Engine's course notes on real-time PBR](http://blog.selfshadow.com/publications/s2013-shading-course/karis/s2013_pbs_epic_notes_v2.pdf), we can reduce this to a single texture lookup by baking the diffuse and specular irradiance contributions of the environment map into textures. You could do this youself as described in the course notes, but there is also a resource called [IBL Baker](http://www.derkreature.com/iblbaker/) that will create these textures for you. The diffuse irradiance can be stored in a cube map, however, we expect the sharpness of specular reflection to diminish as the roughness of the object increases. Because of this, the different amounts of specular irradiance can be stored in the mip levels of the specular cube map and accessed in the fragment shader based on roughness.
 
 **Diffuse Front Face**
 
@@ -113,7 +113,7 @@ In this section, you'll find alternative implementations for the various terms f
 Simplified implementation of fresnel from "An Inexpensive BRDF Model for Physically based Rendering" by Christophe Schlick.
 
 ```
-vec3 fresnelSchlick(PBRInfo pbrInputs)
+vec3 specularReflection(PBRInfo pbrInputs)
 {
   return pbrInputs.metalness + (vec3(1.0) - pbrInputs.metalness) * pow(1.0 - pbrInputs.VdotH, 5.0);
 }
@@ -168,7 +168,7 @@ The following equations model the diffuse term of the lighting equation.
 Implementation of diffuse from "Physically-Based Shading at Disney" by Brent Burley
 
 ```
-vec3 disneyDiffuse(PBRInfo pbrInputs)
+vec3 diffuse(PBRInfo pbrInputs)
 {
   float f90 = 2.0 * pbrInputs.LdotH * pbrInputs.LdotH * pbrInputs.alphaRoughness - 0.5;
 

--- a/mesh.js
+++ b/mesh.js
@@ -8,8 +8,7 @@ class Mesh {
         this.scene = scene;
 
         this.defines = {
-            'USE_MATHS': 1,
-            'USE_IBL': 1,
+            'USE_IBL': 1
         };
 
         this.localState = {
@@ -75,7 +74,7 @@ class Mesh {
             return outStr;
         };
 
-        var shaderDefines = definesToString(this.defines);//"#define USE_SAVED_TANGENTS 1\n#define USE_MATHS 1\n#define USE_IBL 1\n";
+        var shaderDefines = definesToString(this.defines);
         if (globalState.hasLODExtension) {
             shaderDefines += '#define USE_TEX_LOD 1\n';
         }

--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -78,7 +78,6 @@ struct PBRInfo
     float VdotH;                  // cos angle between view direction and half vector
     float perceptualRoughness;    // roughness value, as authored by the model creator (input to shader)
     float metalness;              // metallic value at the surface
-    vec3 baseColor;               // base color of the surface
     vec3 reflectance0;            // full reflectance color (normal incidence angle)
     vec3 reflectance90;           // reflectance color at grazing angle
     float alphaRoughness;         // roughness mapped to a more linear change in the roughness (proposed by [2])
@@ -156,7 +155,7 @@ vec3 getIBLContribution(PBRInfo pbrInputs, vec3 n, vec3 reflection)
 // See also [1], Equation 1
 vec3 diffuse(PBRInfo pbrInputs)
 {
-    return pbrInputs.baseColor / M_PI;
+    return pbrInputs.diffuseColor / M_PI;
 }
 
 // The following equation models the Fresnel reflectance term of the spec equation (aka F())
@@ -205,11 +204,11 @@ void main()
     perceptualRoughness = mrSample.g * perceptualRoughness;
     metallic = mrSample.b * metallic;
 #endif
+    perceptualRoughness = clamp(perceptualRoughness, c_MinRoughness, 1.0);
+    metallic = clamp(metallic, 0.0, 1.0);
     // Roughness is authored as perceptual roughness; as is convention,
     // convert to material roughness by squaring the perceptual roughness [2].
     float alphaRoughness = perceptualRoughness * perceptualRoughness;
-    perceptualRoughness = clamp(perceptualRoughness, c_MinRoughness, 1.0);
-    metallic = clamp(metallic, 0.0, 1.0);
 
     // The albedo may be defined from a base texture or a flat color
 #ifdef HAS_BASECOLORMAP
@@ -252,7 +251,6 @@ void main()
         VdotH,
         perceptualRoughness,
         metallic,
-        baseColor.rgb,
         specularEnvironmentR0,
         specularEnvironmentR90,
         alphaRoughness,

--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -59,60 +59,69 @@ varying vec3 v_Position;
 varying vec2 v_UV;
 
 #ifdef HAS_NORMALS
-  #ifdef HAS_TANGENTS
-    varying mat3 v_TBN;
-  #else
-    varying vec3 v_Normal;
-  #endif
+#ifdef HAS_TANGENTS
+varying mat3 v_TBN;
+#else
+varying vec3 v_Normal;
+#endif
 #endif
 
 // Encapsulate the various inputs used by the various functions in the shading equation
-// We store values in this struct to simply the integration of alternative implementations
+// We store values in this struct to simplify the integration of alternative implementations
 // of the shading terms, outlined in the Readme.MD Appendix.
 struct PBRInfo
 {
-  float NdotL;                  // cos angle between normal and light direction
-  float NdotV;                  // cos angle between normal and view direction
-  float NdotH;                  // cos angle between normal and half vector
-  float LdotH;                  // cos angle between light direction and half vector
-  float VdotH;                  // cos angle between view direction and half vector
-  float perceptualRoughness;    // roughness value, as authored by the model creator (input to shader)
-  float metalness;              // metallic value at the surface
-  vec3 baseColor;               // base color of the surface
-  vec3 reflectance0;            // full reflectance color (normal incidence angle)
-  vec3 reflectance90;           // reflectance color at grazing angle
-  float alphaRoughness;         // roughness mapped to a more linear change in the roughness (proposed by [2])
-  vec3 diffuseColor;            // color contribution from diffuse lighting
-  vec3 specularColor;           // color contribution from specular lighting
+    float NdotL;                  // cos angle between normal and light direction
+    float NdotV;                  // cos angle between normal and view direction
+    float NdotH;                  // cos angle between normal and half vector
+    float LdotH;                  // cos angle between light direction and half vector
+    float VdotH;                  // cos angle between view direction and half vector
+    float perceptualRoughness;    // roughness value, as authored by the model creator (input to shader)
+    float metalness;              // metallic value at the surface
+    vec3 baseColor;               // base color of the surface
+    vec3 reflectance0;            // full reflectance color (normal incidence angle)
+    vec3 reflectance90;           // reflectance color at grazing angle
+    float alphaRoughness;         // roughness mapped to a more linear change in the roughness (proposed by [2])
+    vec3 diffuseColor;            // color contribution from diffuse lighting
+    vec3 specularColor;           // color contribution from specular lighting
 };
 
 const float M_PI = 3.141592653589793;
 const float c_MinRoughness = 0.04;
 
-// Helper function to get the tangent space matrix under several possible model configurations
-mat3 getTangentSpaceMatrix()
+// Find the normal for this fragment, pulling either from a predefined normal map
+// or from the interpolated mesh normal and tangent attributes.
+vec3 getNormal()
 {
-  #ifndef HAS_TANGENTS
+    // Retrieve the tangent space matrix
+#ifndef HAS_TANGENTS
     vec3 pos_dx = dFdx(v_Position);
     vec3 pos_dy = dFdy(v_Position);
     vec3 tex_dx = dFdx(vec3(v_UV, 0.0));
     vec3 tex_dy = dFdy(vec3(v_UV, 0.0));
     vec3 t = (tex_dy.t * pos_dx - tex_dx.t * pos_dy) / (tex_dx.s * tex_dy.t - tex_dy.s * tex_dx.t);
 
-    #ifdef HAS_NORMALS
-      vec3 ng = normalize(v_Normal);
-    #else
-      vec3 ng = cross(pos_dx, pos_dy);
-    #endif
+#ifdef HAS_NORMALS
+    vec3 ng = normalize(v_Normal);
+#else
+    vec3 ng = cross(pos_dx, pos_dy);
+#endif
 
     t = normalize(t - ng * dot(ng, t));
     vec3 b = normalize(cross(ng, t));
     mat3 tbn = mat3(t, b, ng);
-  #else // HAS_TANGENTS && HAS_NORMALS
+#else // HAS_TANGENTS
     mat3 tbn = v_TBN;
-  #endif
+#endif
 
-  return tbn;
+#ifdef HAS_NORMALMAP
+    vec3 n = texture2D(u_NormalSampler, v_UV).rgb;
+    n = normalize(tbn * ((2.0 * n - 1.0) * vec3(u_NormalScale, u_NormalScale, 1.0)));
+#else
+    vec3 n = tbn[2].xyz;
+#endif
+
+    return n;
 }
 
 // Calculation of the lighting contribution from an optional Image Based Light source.
@@ -126,11 +135,11 @@ vec3 getIBLContribution(PBRInfo pbrInputs, vec3 n, vec3 reflection)
     vec3 brdf = texture2D(u_brdfLUT, vec2(pbrInputs.NdotV, 1.0 - pbrInputs.perceptualRoughness)).rgb;
     vec3 diffuseLight = textureCube(u_DiffuseEnvSampler, n).rgb;
 
-    #ifdef USE_TEX_LOD
-      vec3 specularLight = textureCubeLodEXT(u_SpecularEnvSampler, reflection, lod).rgb;
-    #else
-      vec3 specularLight = textureCube(u_SpecularEnvSampler, reflection).rgb;
-    #endif
+#ifdef USE_TEX_LOD
+    vec3 specularLight = textureCubeLodEXT(u_SpecularEnvSampler, reflection, lod).rgb;
+#else
+    vec3 specularLight = textureCube(u_SpecularEnvSampler, reflection).rgb;
+#endif
 
     vec3 diffuse = diffuseLight * pbrInputs.diffuseColor;
     vec3 specular = specularLight * (pbrInputs.specularColor * brdf.x + brdf.y);
@@ -143,18 +152,18 @@ vec3 getIBLContribution(PBRInfo pbrInputs, vec3 n, vec3 reflection)
 }
 
 // Basic Lambertian diffuse
-// implementation from Lambert's Photometria https://archive.org/details/lambertsphotome00lambgoog
+// Implementation from Lambert's Photometria https://archive.org/details/lambertsphotome00lambgoog
 // See also [1], Equation 1
 vec3 diffuse(PBRInfo pbrInputs)
 {
-  return pbrInputs.baseColor / M_PI;
+    return pbrInputs.baseColor / M_PI;
 }
 
-// The following equations model the Fresnel reflectance term of the spec equation (aka F())
-// implementation of fresnel from [4], Equation 15
+// The following equation models the Fresnel reflectance term of the spec equation (aka F())
+// Implementation of fresnel from [4], Equation 15
 vec3 specularReflection(PBRInfo pbrInputs)
 {
-  return pbrInputs.reflectance0 + (pbrInputs.reflectance90 - pbrInputs.reflectance0) * pow(clamp(1.0 - pbrInputs.VdotH, 0.0, 1.0), 5.0);
+    return pbrInputs.reflectance0 + (pbrInputs.reflectance90 - pbrInputs.reflectance0) * pow(clamp(1.0 - pbrInputs.VdotH, 0.0, 1.0), 5.0);
 }
 
 // This calculates the specular geometric attenuation (aka G()),
@@ -163,13 +172,13 @@ vec3 specularReflection(PBRInfo pbrInputs)
 // alphaRoughness as input as originally proposed in [2].
 float geometricOcclusion(PBRInfo pbrInputs)
 {
-  float NdotL = pbrInputs.NdotL;
-  float NdotV = pbrInputs.NdotV;
-  float r = pbrInputs.alphaRoughness;
+    float NdotL = pbrInputs.NdotL;
+    float NdotV = pbrInputs.NdotV;
+    float r = pbrInputs.alphaRoughness;
 
-  float attenuationL = 2.0 * NdotL / (NdotL + sqrt(r * r + (1.0 - r * r) * (NdotL * NdotL)));
-  float attenuationV = 2.0 * NdotV / (NdotV + sqrt(r * r + (1.0 - r * r) * (NdotV * NdotV)));
-  return attenuationL * attenuationV;
+    float attenuationL = 2.0 * NdotL / (NdotL + sqrt(r * r + (1.0 - r * r) * (NdotL * NdotL)));
+    float attenuationV = 2.0 * NdotV / (NdotV + sqrt(r * r + (1.0 - r * r) * (NdotV * NdotV)));
+    return attenuationL * attenuationV;
 }
 
 // The following equation(s) model the distribution of microfacet normals across the area being drawn (aka D())
@@ -177,126 +186,117 @@ float geometricOcclusion(PBRInfo pbrInputs)
 // Follows the distribution function recommended in the SIGGRAPH 2013 course notes from EPIC Games [1], Equation 3.
 float microfacetDistribution(PBRInfo pbrInputs)
 {
-  float roughnessSq = pbrInputs.alphaRoughness * pbrInputs.alphaRoughness;
-  float f = (pbrInputs.NdotH * roughnessSq - pbrInputs.NdotH) * pbrInputs.NdotH + 1.0;
-  return roughnessSq / (M_PI * f * f);
+    float roughnessSq = pbrInputs.alphaRoughness * pbrInputs.alphaRoughness;
+    float f = (pbrInputs.NdotH * roughnessSq - pbrInputs.NdotH) * pbrInputs.NdotH + 1.0;
+    return roughnessSq / (M_PI * f * f);
 }
 
 void main()
 {
-  // Metallic and Roughness material properties are packed together
-  // In glTF, these factors can be specified by fixed scalar values
-  // or from a metallic-roughness map
-  float perceptualRoughness = u_MetallicRoughnessValues.y;
-  float metallic = u_MetallicRoughnessValues.x;
-  #ifdef HAS_METALROUGHNESSMAP
+    // Metallic and Roughness material properties are packed together
+    // In glTF, these factors can be specified by fixed scalar values
+    // or from a metallic-roughness map
+    float perceptualRoughness = u_MetallicRoughnessValues.y;
+    float metallic = u_MetallicRoughnessValues.x;
+#ifdef HAS_METALROUGHNESSMAP
     // Roughness is stored in the 'g' channel, metallic is stored in the 'b' channel.
     // This layout intentionally reserves the 'r' channel for (optional) occlusion map data
     vec4 mrSample = texture2D(u_MetallicRoughnessSampler, v_UV);
     perceptualRoughness = mrSample.g * perceptualRoughness;
     metallic = mrSample.b * metallic;
-  #endif
-  // Roughness is authored as perceptual roughness; as is convention,
-  // convert to material roughness by squaring the perceptual roughness [2].
-  float alphaRoughness = perceptualRoughness * perceptualRoughness;
-  perceptualRoughness = clamp(perceptualRoughness, c_MinRoughness, 1.0);
-  metallic = clamp(metallic, 0.0, 1.0);
+#endif
+    // Roughness is authored as perceptual roughness; as is convention,
+    // convert to material roughness by squaring the perceptual roughness [2].
+    float alphaRoughness = perceptualRoughness * perceptualRoughness;
+    perceptualRoughness = clamp(perceptualRoughness, c_MinRoughness, 1.0);
+    metallic = clamp(metallic, 0.0, 1.0);
 
-  // The albedo may be defined from a base texture or a flat color
-  #ifdef HAS_BASECOLORMAP
+    // The albedo may be defined from a base texture or a flat color
+#ifdef HAS_BASECOLORMAP
     vec4 baseColor = texture2D(u_BaseColorSampler, v_UV) * u_BaseColorFactor;
-  #else
+#else
     vec4 baseColor = u_BaseColorFactor;
-  #endif
+#endif
 
-  vec3 f0 = vec3(0.04);
-  vec3 diffuseColor = baseColor.rgb * (vec3(1.0) - f0);
-  diffuseColor *= 1.0 - metallic;
-  vec3 specularColor = mix(f0, baseColor.rgb, metallic);
+    vec3 f0 = vec3(0.04);
+    vec3 diffuseColor = baseColor.rgb * (vec3(1.0) - f0);
+    diffuseColor *= 1.0 - metallic;
+    vec3 specularColor = mix(f0, baseColor.rgb, metallic);
 
-  // Compute reflectance.
-  float reflectance = max(max(specularColor.r, specularColor.g), specularColor.b);
+    // Compute reflectance.
+    float reflectance = max(max(specularColor.r, specularColor.g), specularColor.b);
 
-  // For typical incident reflectance range (between 4% to 100%) set the grazing reflectance to 100% for typical fresnel effect.
-  // For very low reflectance range on highly diffuse objects (below 4%), incrementally reduce grazing reflecance to 0%.
-  float reflectance90 = clamp(reflectance * 25.0, 0.0, 1.0);
-  vec3 specularEnvironmentR0 = specularColor.rgb;
-  vec3 specularEnvironmentR90 = vec3(1.0, 1.0, 1.0) * reflectance90;
+    // For typical incident reflectance range (between 4% to 100%) set the grazing reflectance to 100% for typical fresnel effect.
+    // For very low reflectance range on highly diffuse objects (below 4%), incrementally reduce grazing reflecance to 0%.
+    float reflectance90 = clamp(reflectance * 25.0, 0.0, 1.0);
+    vec3 specularEnvironmentR0 = specularColor.rgb;
+    vec3 specularEnvironmentR90 = vec3(1.0, 1.0, 1.0) * reflectance90;
 
-  // Find the normal for this fragment, pulling either from a predefined normal map
-  // or from the interpolated mesh normal and tangent attributes.
-  mat3 tbn = getTangentSpaceMatrix();
-  #ifdef HAS_NORMALMAP
-    vec3 n = texture2D(u_NormalSampler, v_UV).rgb;
-    n = normalize(tbn * ((2.0 * n - 1.0) * vec3(u_NormalScale, u_NormalScale, 1.0)));
-  #else
-    vec3 n = tbn[2].xyz;
-  #endif
+    vec3 n = getNormal();                             // normal at surface point
+    vec3 v = normalize(u_Camera - v_Position);        // Vector from surface point to camera
+    vec3 l = normalize(u_LightDirection);             // Vector from surface point to light
+    vec3 h = normalize(l+v);                          // Half vector between both l and v
+    vec3 reflection = -normalize(reflect(v, n));
 
-  vec3 v = normalize(u_Camera - v_Position);        // Vector from surface point to camera
-  vec3 l = normalize(u_LightDirection);             // Vector from surface point to light
-  vec3 h = normalize(l+v);                          // Half vector between both l and v
-  vec3 reflection = -normalize(reflect(v, n));
+    float NdotL = clamp(dot(n, l), 0.001, 1.0);
+    float NdotV = abs(dot(n, v)) + 0.001;
+    float NdotH = clamp(dot(n, h), 0.0, 1.0);
+    float LdotH = clamp(dot(l, h), 0.0, 1.0);
+    float VdotH = clamp(dot(v, h), 0.0, 1.0);
 
-  float NdotL = clamp(dot(n, l), 0.001, 1.0);
-  float NdotV = abs(dot(n, v)) + 0.001;
-  float NdotH = clamp(dot(n, h), 0.0, 1.0);
-  float LdotH = clamp(dot(l, h), 0.0, 1.0);
-  float VdotH = clamp(dot(v, h), 0.0, 1.0);
+    PBRInfo pbrInputs = PBRInfo(
+        NdotL,
+        NdotV,
+        NdotH,
+        LdotH,
+        VdotH,
+        perceptualRoughness,
+        metallic,
+        baseColor.rgb,
+        specularEnvironmentR0,
+        specularEnvironmentR90,
+        alphaRoughness,
+        diffuseColor,
+        specularColor
+    );
 
-  PBRInfo pbrInputs = PBRInfo(
-    NdotL,
-    NdotV,
-    NdotH,
-    LdotH,
-    VdotH,
-    perceptualRoughness,
-    metallic,
-    baseColor.rgb,
-    specularEnvironmentR0,
-    specularEnvironmentR90,
-    alphaRoughness,
-    diffuseColor,
-    specularColor
-  );
+    // Calculate the shading terms for the microfacet specular shading model
+    vec3 F = specularReflection(pbrInputs);
+    float G = geometricOcclusion(pbrInputs);
+    float D = microfacetDistribution(pbrInputs);
 
-  // Calculate the shading terms for the microfacet specular shading model
-  vec3 F = specularReflection(pbrInputs);
-  float G = geometricOcclusion(pbrInputs);
-  float D = microfacetDistribution(pbrInputs);
+    // Calculation of analytical lighting contribution
+    vec3 diffuseContrib = (1.0 - F) * diffuse(pbrInputs);
+    vec3 specContrib = F * G * D / (4.0 * NdotL * NdotV);
+    vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
 
-  // Calculation of analytical lighting contribution
-  vec3 diffuseContrib = (1.0 - F) * diffuse(pbrInputs);
-  vec3 specContrib = F * G * D / (4.0 * NdotL * NdotV);
-  vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
-
-  // Calculate lighting contribution from image based lighting source (IBL)
-  #ifdef USE_IBL
+    // Calculate lighting contribution from image based lighting source (IBL)
+#ifdef USE_IBL
     color += getIBLContribution(pbrInputs, n, reflection);
-  #endif // USE_IBL
+#endif
 
-  // Apply optional PBR terms for additional (optional) shading
-  #ifdef HAS_OCCLUSIONMAP
+    // Apply optional PBR terms for additional (optional) shading
+#ifdef HAS_OCCLUSIONMAP
     float ao = texture2D(u_OcclusionSampler, v_UV).r;
     color = mix(color, color * ao, u_OcclusionStrength);
-  #endif
+#endif
 
-  #ifdef HAS_EMISSIVEMAP
+#ifdef HAS_EMISSIVEMAP
     vec3 emissive = texture2D(u_EmissiveSampler, v_UV).rgb * u_EmissiveFactor;
     color += emissive;
-  #endif
+#endif
 
-  // This section uses mix to override final color for reference app visualization
-  // of various parameters in the lighting equation.
-  color = mix(color, F, u_ScaleFGDSpec.x);
-  color = mix(color, vec3(G), u_ScaleFGDSpec.y);
-  color = mix(color, vec3(D), u_ScaleFGDSpec.z);
-  color = mix(color, specContrib, u_ScaleFGDSpec.w);
+    // This section uses mix to override final color for reference app visualization
+    // of various parameters in the lighting equation.
+    color = mix(color, F, u_ScaleFGDSpec.x);
+    color = mix(color, vec3(G), u_ScaleFGDSpec.y);
+    color = mix(color, vec3(D), u_ScaleFGDSpec.z);
+    color = mix(color, specContrib, u_ScaleFGDSpec.w);
 
-  color = mix(color, diffuseContrib, u_ScaleDiffBaseMR.x);
-  color = mix(color, baseColor.rgb, u_ScaleDiffBaseMR.y);
-  color = mix(color, vec3(metallic), u_ScaleDiffBaseMR.z);
-  color = mix(color, vec3(perceptualRoughness), u_ScaleDiffBaseMR.w);
+    color = mix(color, diffuseContrib, u_ScaleDiffBaseMR.x);
+    color = mix(color, baseColor.rgb, u_ScaleDiffBaseMR.y);
+    color = mix(color, vec3(metallic), u_ScaleDiffBaseMR.z);
+    color = mix(color, vec3(perceptualRoughness), u_ScaleDiffBaseMR.w);
 
-  gl_FragColor = vec4(color, baseColor.a);
+    gl_FragColor = vec4(color, baseColor.a);
 }

--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -66,82 +66,85 @@ struct PBRInfo
   vec3 reflectance0;
   vec3 reflectance90;
   float alphaRoughness;
+  vec3 diffuseColor;
+  vec3 specularColor;
 };
 
 const float M_PI = 3.141592653589793;
 const float c_MinRoughness = 0.04;
 
-// The following equations model the diffuse term of the lighting equation
-// Implementation of diffuse from "Physically-Based Shading at Disney" by Brent Burley
-vec3 disneyDiffuse(PBRInfo pbrInputs)
+// helper function to get the tangent space matrix under several possible model configurations
+mat3 tangentSpaceMatrix()
 {
-  float f90 = 2.0 * pbrInputs.LdotH * pbrInputs.LdotH * pbrInputs.alphaRoughness - 0.5;
+  // Normal Map
+  #ifndef HAS_TANGENTS
+    vec3 pos_dx = dFdx(v_Position);
+    vec3 pos_dy = dFdy(v_Position);
+    vec3 tex_dx = dFdx(vec3(v_UV, 0.0));
+    vec3 tex_dy = dFdy(vec3(v_UV, 0.0));
+    vec3 t = (tex_dy.t * pos_dx - tex_dx.t * pos_dy) / (tex_dx.s * tex_dy.t - tex_dy.s * tex_dx.t);
 
-  return (pbrInputs.baseColor / M_PI) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotL), 5.0)) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotV), 5.0));
+    #ifdef HAS_NORMALS
+      vec3 ng = normalize(v_Normal);
+    #else
+      vec3 ng = cross(pos_dx, pos_dy);
+    #endif
+
+    t = normalize(t - ng * dot(ng, t));
+    vec3 b = normalize(cross(ng, t));
+    mat3 tbn = mat3(t, b, ng);
+  #else // HAS_TANGENTS && HAS_NORMALS
+    mat3 tbn = v_TBN;
+  #endif
+
+  return tbn;
+}
+
+vec3 getIBLContribution(PBRInfo pbrInputs, vec3 n, vec3 reflection)
+{
+    float mipCount = 9.0; // resolution of 512x512
+    float lod = (pbrInputs.perceptualRoughness * mipCount);
+    vec3 brdf = texture2D(u_brdfLUT, vec2(pbrInputs.NdotV, 1.0 - pbrInputs.perceptualRoughness)).rgb;
+    vec3 diffuseLight = textureCube(u_DiffuseEnvSampler, n).rgb;
+
+    #ifdef USE_TEX_LOD
+      vec3 specularLight = textureCubeLodEXT(u_SpecularEnvSampler, reflection, lod).rgb;
+    #else
+      vec3 specularLight = textureCube(u_SpecularEnvSampler, reflection).rgb;
+    #endif
+
+    vec3 diffuse = diffuseLight * pbrInputs.diffuseColor;
+    vec3 specular = specularLight * (pbrInputs.specularColor * brdf.x + brdf.y);
+
+    // For presentation, this allows us to disable IBL terms
+    diffuse *= u_ScaleIBLAmbient.x;
+    specular *= u_ScaleIBLAmbient.y;
+
+    return diffuse + specular;
 }
 
 // basic Lambertian diffuse, implementation from Lambert's Photometria https://archive.org/details/lambertsphotome00lambgoog
-vec3 lambertianDiffuse(PBRInfo pbrInputs)
+vec3 diffuse(PBRInfo pbrInputs)
 {
   return pbrInputs.baseColor / M_PI;
 }
 
 // The following equations model the Fresnel reflectance term of the spec equation (aka F())
 // implementation of fresnel from “An Inexpensive BRDF Model for Physically based Rendering” by Christophe Schlick
-vec3 fresnelSchlick2(PBRInfo pbrInputs)
+vec3 fresnelSchlick(PBRInfo pbrInputs)
 {
   return pbrInputs.reflectance0 + (pbrInputs.reflectance90 - pbrInputs.reflectance0) * pow(clamp(1.0 - pbrInputs.VdotH, 0.0, 1.0), 5.0);
 }
 
-// Simplified implementation of fresnel from “An Inexpensive BRDF Model for Physically based Rendering” by Christophe Schlick
-vec3 fresnelSchlick(PBRInfo pbrInputs)
-{
-  return pbrInputs.metalness + (vec3(1.0) - pbrInputs.metalness) * pow(1.0 - pbrInputs.VdotH, 5.0);
-}
-
-// The following equations model the geometric occlusion term of the spec equation  (aka G())
-// Implementation from “A Reflectance Model for Computer Graphics” by Robert Cook and Kenneth Torrance,
-float geometricOcclusionCookTorrance(PBRInfo pbrInputs)
-{
-  return min(min(2.0 * pbrInputs.NdotV * pbrInputs.NdotH / pbrInputs.VdotH, 2.0 * pbrInputs.NdotL * pbrInputs.NdotH / pbrInputs.VdotH), 1.0);
-}
-
-// implementation of microfacet occlusion from “An Inexpensive BRDF Model for Physically based Rendering” by Christophe Schlick
-float geometricOcclusionSchlick(PBRInfo pbrInputs)
-{
-  float k = pbrInputs.perceptualRoughness * 0.79788; // 0.79788 = sqrt(2.0/3.1415); perceptualRoughness = sqrt(alphaRoughness);
-  // alternately, k can be defined with
-  // float k = (pbrInputs.perceptualRoughness + 1) * (pbrInputs.perceptualRoughness + 1) / 8;
-
-  float l = pbrInputs.LdotH / (pbrInputs.LdotH * (1.0 - k) + k);
-  float n = pbrInputs.NdotH / (pbrInputs.NdotH * (1.0 - k) + k);
-  return l * n;
-}
-
-// the following Smith implementations are from “Geometrical Shadowing of a Random Rough Surface” by Bruce G. Smith
-float geometricOcclusionSmith(PBRInfo pbrInputs)
-{
-  float NdotL2 = pbrInputs.NdotL * pbrInputs.NdotL;
-  float NdotV2 = pbrInputs.NdotV * pbrInputs.NdotV;
-  float v = ( -1.0 + sqrt ( pbrInputs.alphaRoughness * (1.0 - NdotL2 ) / NdotL2 + 1.)) * 0.5;
-  float l = ( -1.0 + sqrt ( pbrInputs.alphaRoughness * (1.0 - NdotV2 ) / NdotV2 + 1.)) * 0.5;
-  return (1.0 / max((1.0 + v + l ), 0.000001));
-}
-
-float SmithG1_var2(float NdotV, float r)
+float GSmithSub(float NdotV, float r)
 {
   float tanSquared = (1.0 - NdotV * NdotV) / max((NdotV * NdotV), 0.00001);
   return 2.0 / (1.0 + sqrt(1.0 + r * r * tanSquared));
 }
 
-float SmithG1(float NdotV, float r)
+float geometricOcclusion(PBRInfo pbrInputs)
 {
-  return 2.0 * NdotV / (NdotV + sqrt(r * r + (1.0 - r * r) * (NdotV * NdotV)));
-}
-
-float geometricOcclusionSmithGGX(PBRInfo pbrInputs)
-{
-  return SmithG1_var2(pbrInputs.NdotL, pbrInputs.alphaRoughness) * SmithG1_var2(pbrInputs.NdotV, pbrInputs.alphaRoughness);
+  return GSmithSub(pbrInputs.NdotL, pbrInputs.alphaRoughness) * GSmithSub(pbrInputs.NdotV, pbrInputs.alphaRoughness);
 }
 
 // The following equation(s) model the distribution of microfacet normals across the area being drawn (aka D())
@@ -155,70 +158,34 @@ float GGX(PBRInfo pbrInputs)
 
 void main()
 {
-  // Normal Map
-  #ifndef HAS_TANGENTS
-  vec3 pos_dx = dFdx(v_Position);
-  vec3 pos_dy = dFdy(v_Position);
-  vec3 tex_dx = dFdx(vec3(v_UV, 0.0));
-  vec3 tex_dy = dFdy(vec3(v_UV, 0.0));
-  vec3 t = (tex_dy.t * pos_dx - tex_dx.t * pos_dy) / (tex_dx.s * tex_dy.t - tex_dy.s * tex_dx.t);
-
-  #ifdef HAS_NORMALS
-  vec3 ng = normalize(v_Normal);
-  #else
-  vec3 ng = cross(pos_dx, pos_dy);
-  #endif
-
-  t = normalize(t - ng * dot(ng, t));
-  vec3 b = normalize(cross(ng, t));
-  mat3 tbn = mat3(t, b, ng);
-  #else // HAS_TANGENTS && HAS_NORMALS
-  mat3 tbn = v_TBN;
-  #endif
-
-  #ifdef HAS_NORMALMAP
-  vec3 n = texture2D(u_NormalSampler, v_UV).rgb;
-  n = normalize(tbn * ((2.0 * n - 1.0) * vec3(u_NormalScale, u_NormalScale, 1.0)));
-  #else
-  vec3 n = tbn[2].xyz;
-  #endif
-
-  vec3 v = normalize(u_Camera - v_Position);
-  vec3 l = normalize(u_LightDirection);
-  vec3 h = normalize(l+v);
-  vec3 reflection = -normalize(reflect(v, n));
-
-  float NdotL = clamp(dot(n, l), 0.001, 1.0);
-  float NdotV = abs(dot(n, v)) + 0.001;
-  float NdotH = clamp(dot(n, h), 0.0, 1.0);
-  float LdotH = clamp(dot(l, h), 0.0, 1.0);
-  float VdotH = clamp(dot(v, h), 0.0, 1.0);
-
+  // Metallic and Roughness material properties are packed together
+  // In glTF, these factors can be specified by fixed scalar values
+  // or from a metallic-roughness map
   float perceptualRoughness = u_MetallicRoughnessValues.y;
   float metallic = u_MetallicRoughnessValues.x;
   #ifdef HAS_METALROUGHNESSMAP
-  vec4 mrSample = texture2D(u_MetallicRoughnessSampler, v_UV);
-  perceptualRoughness = mrSample.g * perceptualRoughness;
-  metallic = mrSample.b * metallic;
+    vec4 mrSample = texture2D(u_MetallicRoughnessSampler, v_UV);
+    perceptualRoughness = mrSample.g * perceptualRoughness;
+    metallic = mrSample.b * metallic;
   #endif
-
+  // Roughness is authored as perceptual roughness; as is convention,
+  // convert to material roughness by squaring the perceptual roughness.
+  // TODO: citation
+  float alphaRoughness = perceptualRoughness * perceptualRoughness;
   perceptualRoughness = clamp(perceptualRoughness, c_MinRoughness, 1.0);
   metallic = clamp(metallic, 0.0, 1.0);
 
+  // The albedo may be defined from a base texture or a flat color
   #ifdef HAS_BASECOLORMAP
-  vec4 baseColor = texture2D(u_BaseColorSampler, v_UV) * u_BaseColorFactor;
+    vec4 baseColor = texture2D(u_BaseColorSampler, v_UV) * u_BaseColorFactor;
   #else
-  vec4 baseColor = u_BaseColorFactor;
+    vec4 baseColor = u_BaseColorFactor;
   #endif
 
   vec3 f0 = vec3(0.04);
-  // is this the same? test!
-  vec3 diffuseColor = mix(baseColor.rgb * (1.0 - f0), vec3(0.0, 0.0, 0.0), metallic);
-  //vec3 diffuseColor = baseColor * (1.0 - metallic);
+  vec3 diffuseColor = baseColor.rgb * (vec3(1.0) - f0);
+  diffuseColor *= 1.0 - metallic;
   vec3 specularColor = mix(f0, baseColor.rgb, metallic);
-
-
-  #ifdef USE_MATHS
 
   // Compute reflectance.
   float reflectance = max(max(specularColor.r, specularColor.g), specularColor.b);
@@ -229,8 +196,26 @@ void main()
   vec3 specularEnvironmentR0 = specularColor.rgb;
   vec3 specularEnvironmentR90 = vec3(1.0, 1.0, 1.0) * reflectance90;
 
-  // roughness is authored as perceptual roughness; as is convention, convert to material roughness by squaring the perceptual roughness
-  float alphaRoughness = perceptualRoughness*perceptualRoughness;
+  // Find the normal for this fragment, pulling either from a predefined normal map
+  // or from the interpolated mesh normal and tangent attributes.
+  mat3 tbn = tangentSpaceMatrix();
+  #ifdef HAS_NORMALMAP
+    vec3 n = texture2D(u_NormalSampler, v_UV).rgb;
+    n = normalize(tbn * ((2.0 * n - 1.0) * vec3(u_NormalScale, u_NormalScale, 1.0)));
+  #else
+    vec3 n = tbn[2].xyz;
+  #endif
+
+  vec3 v = normalize(u_Camera - v_Position);        // View vector
+  vec3 l = normalize(u_LightDirection);             // Light Direction
+  vec3 h = normalize(l+v);                          // Half vector
+  vec3 reflection = -normalize(reflect(v, n));
+
+  float NdotL = clamp(dot(n, l), 0.001, 1.0);
+  float NdotV = abs(dot(n, v)) + 0.001;
+  float NdotH = clamp(dot(n, h), 0.0, 1.0);
+  float LdotH = clamp(dot(l, h), 0.0, 1.0);
+  float VdotH = clamp(dot(v, h), 0.0, 1.0);
 
   PBRInfo pbrInputs = PBRInfo(
     NdotL,
@@ -240,45 +225,29 @@ void main()
     VdotH,
     perceptualRoughness,
     metallic,
-    diffuseColor,
+    baseColor.rgb,
     specularEnvironmentR0,
     specularEnvironmentR90,
-    alphaRoughness
+    alphaRoughness,
+    diffuseColor,
+    specularColor
   );
 
-  vec3 F = fresnelSchlick2(pbrInputs);
-  //vec3 F = fresnelSchlick(pbrInputs);
-  //float G = geometricOcclusionCookTorrance(pbrInputs);
-  //float G = geometricOcclusionSmith(pbrInputs);
-  //float G = geometricOcclusionSchlick(pbrInputs);
-  float G = geometricOcclusionSmithGGX(pbrInputs);
+  vec3 F = fresnelSchlick(pbrInputs);
+  float G = geometricOcclusion(pbrInputs);
   float D = GGX(pbrInputs);
 
-  vec3 diffuseContrib = (1.0 - F) * lambertianDiffuse(pbrInputs);
-  //vec3 diffuseContrib = (1.0 - F) * disneyDiffuse(pbrInputs);
-
+  // Calculation of analytical lighting contribution
+  vec3 diffuseContrib = (1.0 - F) * diffuse(pbrInputs);
   vec3 specContrib = F * G * D / (4.0 * NdotL * NdotV);
-
   vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
-  #endif
 
+  // Calculate lighting contribution from image based lighting source (IBL)
   #ifdef USE_IBL
-  float mipCount = 9.0; // resolution of 512x512
-  float lod = (perceptualRoughness * mipCount);
-  vec3 brdf = texture2D(u_brdfLUT, vec2(NdotV, 1.0 - perceptualRoughness)).rgb;
-  vec3 diffuseLight = textureCube(u_DiffuseEnvSampler, n).rgb;
+    color += getIBLContribution(pbrInputs, n, reflection);
+  #endif // USE_IBL
 
-  #ifdef USE_TEX_LOD
-  vec3 specularLight = textureCubeLodEXT(u_SpecularEnvSampler, reflection, lod).rgb;
-  #else
-  vec3 specularLight = textureCube(u_SpecularEnvSampler, reflection).rgb;
-  #endif
-
-  vec3 IBLcolor = (diffuseLight * diffuseColor * u_ScaleIBLAmbient.x) + (specularLight * (specularColor * brdf.x + brdf.y) *u_ScaleIBLAmbient.y);
-
-  color += IBLcolor;
-  #endif
-
+  // Apply optional PBR terms for additional (optional) shading
   #ifdef HAS_OCCLUSIONMAP
     float ao = texture2D(u_OcclusionSampler, v_UV).r;
     color = mix(color, color * ao, u_OcclusionStrength);
@@ -289,8 +258,8 @@ void main()
     color += emissive;
   #endif
 
-  #ifdef USE_MATHS
-  // mix in overrides
+  // This section uses mix to override final color for reference app visualization
+  // of various parameters in the lighting equation.
   color = mix(color, F, u_ScaleFGDSpec.x);
   color = mix(color, vec3(G), u_ScaleFGDSpec.y);
   color = mix(color, vec3(D), u_ScaleFGDSpec.z);
@@ -300,10 +269,6 @@ void main()
   color = mix(color, baseColor.rgb, u_ScaleDiffBaseMR.y);
   color = mix(color, vec3(metallic), u_ScaleDiffBaseMR.z);
   color = mix(color, vec3(perceptualRoughness), u_ScaleDiffBaseMR.w);
-  #endif
 
   gl_FragColor = vec4(color, baseColor.a);
-  //gl_FragColor = vec4(n * 0.5 + 0.5, 1.0);
-  //gl_FragColor = vec4(NdotV, NdotV, NdotV, 1.0);
-  //gl_FragColor = vec4(v_UV.rg, 0.0, 1.0);
 }


### PR DESCRIPTION
Opening a PR for discussion on #44

Fairly hefty cleanup and reorganization attempt based on feedback in #44.
 * Moved unused shading factor implementations out into the readme.  With PBRInputs struct, these can be easily swapped in for comparison
 * Lots of code documentation, tracked down references mostly to the Epic Paper
 * Renamed some core functions, with influence from @javagl's implementation
 * Minor change/correction to calculation of `diffuseColor`.  Model lighting looks too dark and changed it to a more intuitive implemenation.  f0 is the reflection contribution at grazing angle, so the diffuse contribution is the inverse of that, and then adjusted by the inverse of the metallic.
 * Switched the `geometricOcclusion` to use the `SmithG1` sub-function.  I also removed the additional sub-function and inlined the implementation within the `geometricOcclusion` function for clarity.  We were using the `SmithG1_var2`, but I could not track down a reference.

TODO:

- [x] Track down reference for SmithG1_var2, select a preferred implementation
- [ ] Cleanup Appendix, determine if this is even necessary or if we simply provide a single and simple reference implementation.
