### PR TITLE
Small Explanations on Intensity vs Reflectance

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ vec3 specContrib = F * G * D / (4.0 * NdotL * NdotV);
 vec3 diffuseContrib = (1.0 - F) * diffuse;
 ```
 
+If you're familiar with implementing the phong model, you may think that the diffuse and specular contributions simply need to be summed up to obtain the final lighting. However, in the context of a BRDF, the diffuse and specular components are not accounting for the *energy* of the incident light, which can cause some confusion.
+Using a BRDF, the diffuse and specular parts describe the *bidirectional reflectance*, which we have to scale by the *energy* received from the light in order to obtain the final intensity that reaches the eye of the viewer (as outlined in the respective [paper by Cook and Torrance](http://graphics.pixar.com/library/ReflectanceModel/).
+According to the basic cosine law (as described by [Lambert](https://archive.org/details/lambertsphotome00lambgoog)), the energy is computed using the dot product between the light's direction and the surface normal. Therefore, the final intensity that will be used for shading is computed as follows:
+```
+vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
+```
+
 Below here you'll find common implementations for the various terms found in the lighting equation.
 These functions may be swapped into pbr-frag.glsl to tune your desired rendering performance and presentation.
 

--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -281,6 +281,7 @@ void main()
     // Calculation of analytical lighting contribution
     vec3 diffuseContrib = (1.0 - F) * diffuse(pbrInputs);
     vec3 specContrib = F * G * D / (4.0 * NdotL * NdotV);
+    // Obtain final intensity as reflectance (BRDF) scaled by the energy of the light (cosine law)
     vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
 
     // Calculate lighting contribution from image based lighting source (IBL)


### PR DESCRIPTION
Hi all,

I just used this demo for a small recap of PBR basics, which worked nicely because it contains explanations in the README, it is able to visualize the impact of different parts of the BRDF, and the code is also pretty readable and has a lot of comments. So, it's pretty good for education :-)

However, I stumbled upon one thing that could possibly be documented explicitly, but it's not so far. Inside the fragment shader, the final lighting is computed as
```
vec3 color = NdotL * u_LightColor * (diffuseContrib + specContrib);
```
Especially when coming from a context where one has already implemented the Blinn-Phong model, this can look a bit confusing: Why does this equation not just sum up diffuse and specular parts of the "lighting"? And why do they not put just another `NdotL` factor into the `diffuseContrib` and `specContrib` parts instead?
The answer is that the terms "specular" and "diffuse" mean something slightly different in this context of a BRDF than they do for common Blinn-Phong implementations, since the BRDF does not compute the final *intensity* but just *bidirectional reflectance*, and hence the values need to be scaled by the *energy*, computed via the (Lambert) cosine law, therefore the "additional" `NdotL`. Personally, I find this circumstances confusing enough to justify a comment on that inside the shader and an additional explanation in the Appendix inside the README, which I added as part of this PR.

It's just a small suggestion of course, and I'm not a native speaker - so, please, feel free to change wording etc. Thanks & keep up the great work!



