### PR TITLE
Fixed a bug where NdotV can be >1.0

### DIFF
--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -254,7 +254,7 @@ void main()
     vec3 reflection = -normalize(reflect(v, n));
 
     float NdotL = clamp(dot(n, l), 0.001, 1.0);
-    float NdotV = abs(dot(n, v)) + 0.001;
+    float NdotV = clamp(abs(dot(n, v)), 0.001, 1.0);
     float NdotH = clamp(dot(n, h), 0.0, 1.0);
     float LdotH = clamp(dot(l, h), 0.0, 1.0);
     float VdotH = clamp(dot(v, h), 0.0, 1.0);


### PR DESCRIPTION
Fixed a bug where `NdotV` can be `>1.0` resulting in a black spot if used with the diffuse term from "Disney implementation of diffuse from Physically-Based Shading at Disney" by Brent Burley.

```
vec3 diffuse(PBRInfo pbrInputs)
{
    float f90 = 2.0 * pbrInputs.LdotH * pbrInputs.LdotH * pbrInputs.alphaRoughness - 0.5;

    return (pbrInputs.diffuseColor / M_PI) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotL), 5.0)) * (1.0 + f90 * pow((1.0 - pbrInputs.NdotV), 5.0));
}
```

The term `1.0-pbrInputs.NdotV` will become negative.