### PR TITLE
Wrap getIBLContribution with #ifdef USE_IBL

### DIFF
--- a/shaders/pbr-frag.glsl
+++ b/shaders/pbr-frag.glsl
@@ -142,6 +142,7 @@ vec3 getNormal()
 // Calculation of the lighting contribution from an optional Image Based Light source.
 // Precomputed Environment Maps are required uniform inputs and are computed as outlined in [1].
 // See our README.md on Environment Maps [3] for additional discussion.
+#ifdef USE_IBL
 vec3 getIBLContribution(PBRInfo pbrInputs, vec3 n, vec3 reflection)
 {
     float mipCount = 9.0; // resolution of 512x512
@@ -165,6 +166,7 @@ vec3 getIBLContribution(PBRInfo pbrInputs, vec3 n, vec3 reflection)
 
     return diffuse + specular;
 }
+#endif
 
 // Basic Lambertian diffuse
 // Implementation from Lambert's Photometria https://archive.org/details/lambertsphotome00lambgoog


### PR DESCRIPTION
Without this the shader may fail compilation because the uniforms used in the getIBLContribution function are not being declared.