### PR TITLE
Windows EOL fix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Turn off text-based EOL adaptations for various image formats.
+*.jpg -text
+*.JPG -text
+*.png -text
+*.hdr -text


### PR DESCRIPTION
Git had mistaken some of the smaller HDR files for text-based files, not binary.  This change to `.gitattributes` specifically marks all such image files as binary files, to protect them from end-of-line processing.

On Windows, `\n` in HDR files were being automatically converted to `\r\n`, which caused an infinite loop to appear here:

https://github.com/KhronosGroup/glTF-WebGL-PBR/blob/3186d988507d2bf94ff2940c2e2cf1b597a5d691/libs/hdrpng.js#L156

The corrupted files never matched the regex, and the entire browser hung.

NOTE for Windows users: After pulling this change, you may need to manually delete your `assets/images` folder, as it will still contain the old corrupted files.  Then use git commands to recreate the folder locally.  (I didn't have other pending changes, so I took the heavy-handed approach of `git reset --hard` on my copy.  Make sure you have anything important checked in first.)