### PR TITLE
Node depth sort fix

### DIFF
--- a/src/camera.js
+++ b/src/camera.js
@@ -25,6 +25,30 @@ class gltfCamera
         this.node = nodeIndex;
     }
 
+    sortNodesByDepth(nodes)
+    {
+        // precompute the distances to avoid their computation during sorting
+        const sortedNodes = [];
+        for (const node of nodes)
+        {
+            const modelView = mat4.create();
+            mat4.multiply(modelView, this.getViewMatrix(), node.worldTransform);
+
+            const pos = vec3.create();
+            mat4.getTranslation(pos, modelView);
+
+            sortedNodes.push({depth: pos[2], node: node})
+        }
+
+        // remove nodes that are behind the camera
+        // --> will never be visible and it is cheap to discard them here
+        sortedNodes.filter((a) => a.depth >= 0);
+
+        sortedNodes.sort((a, b) => b.depth - a.depth);
+
+        return sortedNodes.map((a) => a.node);
+    }
+
     getProjectionMatrix()
     {
         const projection = mat4.create();

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -116,18 +116,15 @@ class gltfRenderer
 
         mat4.multiply(this.viewProjectionMatrix, this.projMatrix, this.viewMatrix);
 
+        let nodes = scene.gatherNodes(gltf);
         if(sortByDepth)
         {
-            scene.sortSceneByDepth(gltf, this.viewProjectionMatrix);
+            nodes = currentCamera.sortNodesByDepth(nodes);
         }
 
-        let nodeIndices = scene.nodes.slice();
-        while (nodeIndices.length > 0)
+        for (const node of nodes)
         {
-            const nodeIndex = nodeIndices.pop();
-            const node = gltf.nodes[nodeIndex];
             this.drawNode(gltf, node);
-            nodeIndices = nodeIndices.concat(node.children);
         }
     }
 

--- a/src/scene.js
+++ b/src/scene.js
@@ -78,44 +78,28 @@ class gltfScene
         return new gltfScene(Nodes, this.name);
     }
 
-    sortSceneByDepth(gltf, viewProjectionMatrix)
+    gatherNodes(gltf)
     {
-        // vector of {abs position, nodeIndex}
-        const posNodes = [];
+        const nodes = [];
 
-        function addPosNode(nodeIndex)
+        function gatherNode(nodeIndex)
         {
             const node = gltf.nodes[nodeIndex];
-
-            const modelView = mat4.create();
-            mat4.multiply(modelView, viewProjectionMatrix, node.worldTransform);
-
-            const pos = vec3.create();
-            mat4.getTranslation(pos, modelView);
-
-            // TODO: we could clip objects behind the camera
-            posNodes.push({ depth: pos[2], idx: nodeIndex });
+            nodes.push(node);
 
             // recurse into children
-            for(const c of node.children)
+            for(const child of node.children)
             {
-                addPosNode(gltf.nodes[c]);
+                gatherNode(child);
             }
         }
 
-        for (const n of this.nodes)
+        for (const node of this.nodes)
         {
-            addPosNode(n);
+            gatherNode(node);
         }
 
-        // high z far from camera first
-        posNodes.sort((a, b) => b.depth - a.depth);
-
-        this.nodes = [];
-        for(const node of posNodes)
-        {
-            this.nodes.push(node.idx)
-        }
+        return nodes;
     }
 
     includesNode(gltf, nodeIndex)


### PR DESCRIPTION
when sorting nodes by depth for transparency rendering, children may be drawn multiple times. 
This pull request fixes this issue and separates the gathering and sorting of nodes.